### PR TITLE
add gh actions to update "stable" directory

### DIFF
--- a/.github/workflows/stable-dir.yaml
+++ b/.github/workflows/stable-dir.yaml
@@ -1,0 +1,39 @@
+name: Update Stable Directory
+
+on: 
+  push:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Get the latest stable version number
+        id: get-latest-version
+        run: echo "::set-output name=version::$(cat latest_release.txt)"
+
+      - name: Delete current "stable" directory
+        run: |
+          git rm -r stable
+
+      - name: Copy latest stable version content to "stable" directory
+        run: |
+          mkdir stable
+          cp -a ${{ steps.get-latest-version.outputs.version }}/* stable
+
+      - name: Commit and push
+        run: |
+          git add -A
+          git commit -m "Update stable dir"
+          git push


### PR DESCRIPTION
This PR adds the stable-dir.yaml file which instructs GH Actions to copy the contents from the latest stable release to the "stable" directory. This allows users to browse the stable doc site using the \stable URL instead of a specific version number. 

Please approve the PR here first: https://github.com/cleanlab/cleanlab/pull/231, before approving this one. 