### PR TITLE
Include check for stable version

### DIFF
--- a/stable/_modules/cleanlab/benchmarking/noise_generation.html
+++ b/stable/_modules/cleanlab/benchmarking/noise_generation.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/classification.html
+++ b/stable/_modules/cleanlab/classification.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/count.html
+++ b/stable/_modules/cleanlab/count.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/dataset.html
+++ b/stable/_modules/cleanlab/dataset.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/experimental/cifar_cnn.html
+++ b/stable/_modules/cleanlab/experimental/cifar_cnn.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/experimental/coteaching.html
+++ b/stable/_modules/cleanlab/experimental/coteaching.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/experimental/fasttext.html
+++ b/stable/_modules/cleanlab/experimental/fasttext.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/experimental/mnist_pytorch.html
+++ b/stable/_modules/cleanlab/experimental/mnist_pytorch.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/filter.html
+++ b/stable/_modules/cleanlab/filter.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/internal/label_quality_utils.html
+++ b/stable/_modules/cleanlab/internal/label_quality_utils.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/internal/latent_algebra.html
+++ b/stable/_modules/cleanlab/internal/latent_algebra.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/internal/util.html
+++ b/stable/_modules/cleanlab/internal/util.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/cleanlab/rank.html
+++ b/stable/_modules/cleanlab/rank.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/_modules/index.html
+++ b/stable/_modules/index.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/benchmarking/index.html
+++ b/stable/cleanlab/benchmarking/index.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/benchmarking/noise_generation.html
+++ b/stable/cleanlab/benchmarking/noise_generation.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/classification.html
+++ b/stable/cleanlab/classification.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/count.html
+++ b/stable/cleanlab/count.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/dataset.html
+++ b/stable/cleanlab/dataset.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/experimental/cifar_cnn.html
+++ b/stable/cleanlab/experimental/cifar_cnn.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/experimental/coteaching.html
+++ b/stable/cleanlab/experimental/coteaching.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/experimental/fasttext.html
+++ b/stable/cleanlab/experimental/fasttext.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/experimental/index.html
+++ b/stable/cleanlab/experimental/index.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/experimental/mnist_pytorch.html
+++ b/stable/cleanlab/experimental/mnist_pytorch.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/filter.html
+++ b/stable/cleanlab/filter.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/internal/index.html
+++ b/stable/cleanlab/internal/index.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/internal/label_quality_utils.html
+++ b/stable/cleanlab/internal/label_quality_utils.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/internal/latent_algebra.html
+++ b/stable/cleanlab/internal/latent_algebra.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/internal/util.html
+++ b/stable/cleanlab/internal/util.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/cleanlab/rank.html
+++ b/stable/cleanlab/rank.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/index.html
+++ b/stable/index.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/migrating/migrate_v2.html
+++ b/stable/migrating/migrate_v2.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/tutorials/audio.html
+++ b/stable/tutorials/audio.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/tutorials/dataset_health.html
+++ b/stable/tutorials/dataset_health.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/tutorials/image.html
+++ b/stable/tutorials/image.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/tutorials/indepth_overview.html
+++ b/stable/tutorials/indepth_overview.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/tutorials/index.html
+++ b/stable/tutorials/index.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/tutorials/pred_probs_cross_val.html
+++ b/stable/tutorials/pred_probs_cross_val.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/tutorials/tabular.html
+++ b/stable/tutorials/tabular.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>

--- a/stable/tutorials/text.html
+++ b/stable/tutorials/text.html
@@ -335,7 +335,7 @@
             <p class="admonition-title">Warning</p>
             <p>This version of the documentation corresponds to the master branch of <code class="docutils literal notranslate"><span class="pre">cleanlab</span></code> source code from <a href="https://github.com/cleanlab/cleanlab/">GitHub</a>. To see the documentation for the latest <code class="docutils literal notranslate"><span class="pre">pip</span></code>-installed version, click <a href="/">here</a>.</p>
             </div>`;
-        } else if (!path_arr.includes(version_number)) {
+        } else if (!path_arr.includes(version_number) && !path_arr.includes("stable")) {
             document.getElementById("doc_ver_warning").innerHTML =
             `<div class="admonition warning">
             <p class="admonition-title">Warning</p>


### PR DESCRIPTION
There are 40 pages on the stable version of the docs that have an "old-version" warning banner.
With this check on the stable version of the docs, the banner is removed.

## Before PR
![before_pr](https://user-images.githubusercontent.com/18127060/186638394-36fcc970-3a8a-498e-a015-87f07326eabd.png)


## After PR
![after_pr](https://user-images.githubusercontent.com/18127060/186638429-83df1348-8110-4cf2-bf4b-18e351b3a275.png)


The affected lines are updated with:

```bash
#!/bin/bash
FIND='} else if (!path_arr.includes(version_number)) {'
REPLACE='} else if (!path_arr.includes(version_number) \&\& !path_arr.includes("stable")) {'

# Replace the string in all files in stable/ (40 occurrences)
find stable -type f -exec sed -i "s/$FIND/$REPLACE/g" {} +
```

---

- Closes cleanlab/cleanlab#300
  - Maybe create a separate issue for updating external links?
- Refs. cleanlab/cleanlab#378