### PR TITLE
Catch error code of git diff

### DIFF
--- a/.github/workflows/stable-dir.yaml
+++ b/.github/workflows/stable-dir.yaml
@@ -35,5 +35,4 @@ jobs:
       - name: Commit and push
         run: |
           git add -A
-          git commit -m "Update stable dir"
-          git push
+          git diff-index --quiet HEAD || ( git commit -m "Update stable dir" && git push )


### PR DESCRIPTION
The "Update Stable Directory" workflow fails when no changes are made to the stable docs because `git commit` expects changes to the stable docs.

