### PR TITLE
Rebuild v2.1.0 tutorials (pt 3: correct install versions)

### DIFF
--- a/stable/_sources/tutorials/audio.ipynb
+++ b/stable/_sources/tutorials/audio.ipynb
@@ -93,7 +93,7 @@
     "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\" \n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/_sources/tutorials/dataset_health.ipynb
+++ b/stable/_sources/tutorials/dataset_health.ipynb
@@ -77,7 +77,7 @@
     "dependencies = [\"cleanlab\", \"requests\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/_sources/tutorials/image.ipynb
+++ b/stable/_sources/tutorials/image.ipynb
@@ -89,7 +89,7 @@
     "dependencies = [\"cleanlab\", \"matplotlib\", \"torch\", \"torchvision\", \"skorch\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/_sources/tutorials/indepth_overview.ipynb
+++ b/stable/_sources/tutorials/indepth_overview.ipynb
@@ -62,7 +62,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\", \"matplotlib\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/_sources/tutorials/multiannotator.ipynb
+++ b/stable/_sources/tutorials/multiannotator.ipynb
@@ -91,7 +91,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/_sources/tutorials/outliers.ipynb
+++ b/stable/_sources/tutorials/outliers.ipynb
@@ -119,7 +119,7 @@
     "dependencies = [\"matplotlib\", \"torch\", \"torchvision\", \"sklearn\", \"timm\", \"cleanlab\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/_sources/tutorials/tabular.ipynb
+++ b/stable/_sources/tutorials/tabular.ipynb
@@ -92,7 +92,7 @@
     "!pip install cleanlab\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",
-    "#     !pip install git+https://github.com/cleanlab/cleanlab.git\n",
+    "#     !pip install cleanlab==v2.1.0\n",
     "```"
    ]
   },

--- a/stable/_sources/tutorials/text.ipynb
+++ b/stable/_sources/tutorials/text.ipynb
@@ -117,7 +117,7 @@
     "logging.getLogger('tensorflow').setLevel(logging.FATAL) \n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/_sources/tutorials/token_classification.ipynb
+++ b/stable/_sources/tutorials/token_classification.ipynb
@@ -95,7 +95,7 @@
     "dependencies = [\"cleanlab\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/audio.ipynb
+++ b/stable/tutorials/audio.ipynb
@@ -110,7 +110,7 @@
     "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\" \n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/dataset_health.ipynb
+++ b/stable/tutorials/dataset_health.ipynb
@@ -83,7 +83,7 @@
     "dependencies = [\"cleanlab\", \"requests\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/image.ipynb
+++ b/stable/tutorials/image.ipynb
@@ -95,7 +95,7 @@
     "dependencies = [\"cleanlab\", \"matplotlib\", \"torch\", \"torchvision\", \"skorch\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/indepth_overview.ipynb
+++ b/stable/tutorials/indepth_overview.ipynb
@@ -68,7 +68,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\", \"matplotlib\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/multiannotator.ipynb
+++ b/stable/tutorials/multiannotator.ipynb
@@ -97,7 +97,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/outliers.ipynb
+++ b/stable/tutorials/outliers.ipynb
@@ -134,7 +134,7 @@
     "dependencies = [\"matplotlib\", \"torch\", \"torchvision\", \"sklearn\", \"timm\", \"cleanlab\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/tabular.ipynb
+++ b/stable/tutorials/tabular.ipynb
@@ -114,7 +114,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/text.ipynb
+++ b/stable/tutorials/text.ipynb
@@ -123,7 +123,7 @@
     "logging.getLogger('tensorflow').setLevel(logging.FATAL) \n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/stable/tutorials/token_classification.ipynb
+++ b/stable/tutorials/token_classification.ipynb
@@ -244,7 +244,7 @@
     "dependencies = [\"cleanlab\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/_sources/tutorials/audio.ipynb
+++ b/v2.1.0/_sources/tutorials/audio.ipynb
@@ -93,7 +93,7 @@
     "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\" \n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/_sources/tutorials/dataset_health.ipynb
+++ b/v2.1.0/_sources/tutorials/dataset_health.ipynb
@@ -77,7 +77,7 @@
     "dependencies = [\"cleanlab\", \"requests\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/_sources/tutorials/image.ipynb
+++ b/v2.1.0/_sources/tutorials/image.ipynb
@@ -89,7 +89,7 @@
     "dependencies = [\"cleanlab\", \"matplotlib\", \"torch\", \"torchvision\", \"skorch\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/_sources/tutorials/indepth_overview.ipynb
+++ b/v2.1.0/_sources/tutorials/indepth_overview.ipynb
@@ -62,7 +62,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\", \"matplotlib\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/_sources/tutorials/multiannotator.ipynb
+++ b/v2.1.0/_sources/tutorials/multiannotator.ipynb
@@ -91,7 +91,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/_sources/tutorials/outliers.ipynb
+++ b/v2.1.0/_sources/tutorials/outliers.ipynb
@@ -119,7 +119,7 @@
     "dependencies = [\"matplotlib\", \"torch\", \"torchvision\", \"sklearn\", \"timm\", \"cleanlab\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/_sources/tutorials/tabular.ipynb
+++ b/v2.1.0/_sources/tutorials/tabular.ipynb
@@ -92,7 +92,7 @@
     "!pip install cleanlab\n",
     "# Make sure to install the version corresponding to this tutorial\n",
     "# E.g. if viewing master branch documentation:\n",
-    "#     !pip install git+https://github.com/cleanlab/cleanlab.git\n",
+    "#     !pip install cleanlab==v2.1.0\n",
     "```"
    ]
   },

--- a/v2.1.0/_sources/tutorials/text.ipynb
+++ b/v2.1.0/_sources/tutorials/text.ipynb
@@ -117,7 +117,7 @@
     "logging.getLogger('tensorflow').setLevel(logging.FATAL) \n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/_sources/tutorials/token_classification.ipynb
+++ b/v2.1.0/_sources/tutorials/token_classification.ipynb
@@ -95,7 +95,7 @@
     "dependencies = [\"cleanlab\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/audio.ipynb
+++ b/v2.1.0/tutorials/audio.ipynb
@@ -110,7 +110,7 @@
     "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\" \n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/dataset_health.ipynb
+++ b/v2.1.0/tutorials/dataset_health.ipynb
@@ -83,7 +83,7 @@
     "dependencies = [\"cleanlab\", \"requests\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/image.ipynb
+++ b/v2.1.0/tutorials/image.ipynb
@@ -95,7 +95,7 @@
     "dependencies = [\"cleanlab\", \"matplotlib\", \"torch\", \"torchvision\", \"skorch\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/indepth_overview.ipynb
+++ b/v2.1.0/tutorials/indepth_overview.ipynb
@@ -68,7 +68,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\", \"matplotlib\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/multiannotator.ipynb
+++ b/v2.1.0/tutorials/multiannotator.ipynb
@@ -97,7 +97,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/outliers.ipynb
+++ b/v2.1.0/tutorials/outliers.ipynb
@@ -134,7 +134,7 @@
     "dependencies = [\"matplotlib\", \"torch\", \"torchvision\", \"sklearn\", \"timm\", \"cleanlab\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/tabular.ipynb
+++ b/v2.1.0/tutorials/tabular.ipynb
@@ -114,7 +114,7 @@
     "dependencies = [\"cleanlab\", \"sklearn\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/text.ipynb
+++ b/v2.1.0/tutorials/text.ipynb
@@ -123,7 +123,7 @@
     "logging.getLogger('tensorflow').setLevel(logging.FATAL) \n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",

--- a/v2.1.0/tutorials/token_classification.ipynb
+++ b/v2.1.0/tutorials/token_classification.ipynb
@@ -244,7 +244,7 @@
     "dependencies = [\"cleanlab\"]\n",
     "\n",
     "if \"google.colab\" in str(get_ipython()):  # Check if it's running in Google Colab\n",
-    "    %pip install git+https://github.com/cleanlab/cleanlab.git@d27478853f928feb73d0cd2d35fc36bb48211e52\n",
+    "    %pip install cleanlab==v2.1.0\n",
     "    cmd = ' '.join([dep for dep in dependencies if dep != \"cleanlab\"])\n",
     "    %pip install $cmd\n",
     "else:\n",


### PR DESCRIPTION
Make install versions of cleanlab package in notebooks/colabs match v2.1, which they did not when copying over docs from master version.